### PR TITLE
Device compute snapshot

### DIFF
--- a/Samples/ComputeOnDevice/AppMain.cpp
+++ b/Samples/ComputeOnDevice/AppMain.cpp
@@ -29,13 +29,6 @@ namespace ComputeOnDevice
     void AppMain::OnHolographicSpaceChanged(
         Windows::Graphics::Holographic::HolographicSpace^ holographicSpace)
     {
-        /*
-        _currentSlateRenderer =
-            std::make_shared<Rendering::SlateRenderer>(
-                _deviceResources);
-        _slateRendererList.push_back(_currentSlateRenderer);
-        */
-
         //
         // Initialize the HoloLens media frame readers
         //
@@ -48,11 +41,6 @@ namespace ComputeOnDevice
         Windows::Perception::Spatial::SpatialCoordinateSystem^ currentCoordinateSystem =
             _spatialPerception->GetOriginFrameOfReference()->CoordinateSystem;
 
-        // When you get input 
-        // 1. Set the current texture to be displayed on the previous slate
-        // 2. create a new texture as the current texture
-        // 3. create a new slaterender for the new position and push it the list
-        // 4. position the new slate renderer
         if (!_isActiveRenderer)
         {
             _currentSlateRenderer =
@@ -72,8 +60,6 @@ namespace ComputeOnDevice
             // Freeze frame
             _visualizationTextureList.push_back(_currentVisualizationTexture);
             _currentVisualizationTexture = nullptr;
-            
-
             _isActiveRenderer = false;
         }
     }
@@ -243,7 +229,6 @@ namespace ComputeOnDevice
         {
             r->ReleaseDeviceDependentResources();
         }
-        //_currentSlateRenderer->ReleaseDeviceDependentResources();
 
         _holoLensMediaFrameSourceGroup = nullptr;
         _holoLensMediaFrameSourceGroupStarted = false;
@@ -263,7 +248,6 @@ namespace ComputeOnDevice
         {
             r->CreateDeviceDependentResources();
         }
-        //_currentSlateRenderer->CreateDeviceDependentResources();
 
         StartHoloLensMediaFrameSourceGroup();
     }

--- a/Samples/ComputeOnDevice/AppMain.h
+++ b/Samples/ComputeOnDevice/AppMain.h
@@ -44,7 +44,8 @@ namespace ComputeOnDevice
         void StartHoloLensMediaFrameSourceGroup();
 
     private:
-        std::unique_ptr<Rendering::SlateRenderer> _slateRenderer;
+        std::vector<std::shared_ptr<Rendering::SlateRenderer> >_slateRendererList;
+        std::shared_ptr<Rendering::SlateRenderer> _currentSlateRenderer;
 
         // Selected HoloLens media frame source group
         HoloLensForCV::MediaFrameSourceGroupType _selectedHoloLensMediaFrameSourceGroupType;
@@ -65,6 +66,9 @@ namespace ComputeOnDevice
         cv::Mat _blurredPVCameraImage;
         cv::Mat _cannyPVCameraImage;
 
-        Rendering::Texture2DPtr _visualizationTexture;
+        std::vector<Rendering::Texture2DPtr> _visualizationTextureList;
+        Rendering::Texture2DPtr _currentVisualizationTexture;
+
+        bool _isActiveRenderer;
     };
 }


### PR DESCRIPTION
In demos, viewing canny detector results through MRV is very difficult as MRV can be very jittery. This enables the ability to snapshot the last canny detector results as slate, which is easier to view for demo. 