### PR TITLE
Api/feature updates/fixes

### DIFF
--- a/Shared/HoloLensForCV/MediaFrameReaderContext.cpp
+++ b/Shared/HoloLensForCV/MediaFrameReaderContext.cpp
@@ -188,11 +188,11 @@ namespace HoloLensForCV
         {
             Platform::Object^ mfMtUserData =
                 frame->Properties->Lookup(c_MFSampleExtension_Spatial_CameraViewTransform);
-            Platform::Array<byte>^ cameraVBewTransformAsPlatformArray =
+            Platform::Array<byte>^ cameraViewTransformAsPlatformArray =
                 safe_cast<Platform::IBoxArray<byte>^>(mfMtUserData)->Value;
             sensorFrame->CameraViewTransform =
                 *reinterpret_cast<Windows::Foundation::Numerics::float4x4*>(
-                    cameraVBewTransformAsPlatformArray->Data);
+                    cameraViewTransformAsPlatformArray->Data);
 
 #if DBG_ENABLE_VERBOSE_LOGGING
             auto cameraViewTransform = sensorFrame->CameraViewTransform;
@@ -230,11 +230,11 @@ namespace HoloLensForCV
         {
             Platform::Object^ mfMtUserData =
                 frame->Properties->Lookup(c_MFSampleExtension_Spatial_CameraProjectionTransform);
-            Platform::Array<byte>^ cameraVBewTransformAsPlatformArray =
+            Platform::Array<byte>^ cameraProjectionTransformAsPlatformArray =
                 safe_cast<Platform::IBoxArray<byte>^>(mfMtUserData)->Value;
             sensorFrame->CameraProjectionTransform =
                 *reinterpret_cast<Windows::Foundation::Numerics::float4x4*>(
-                    cameraVBewTransformAsPlatformArray->Data);
+                    cameraProjectionTransformAsPlatformArray->Data);
 
 #if DBG_ENABLE_VERBOSE_LOGGING
             auto cameraProjectionTransform = sensorFrame->CameraProjectionTransform;

--- a/Shared/HoloLensForCV/SensorFrameRecorder.cpp
+++ b/Shared/HoloLensForCV/SensorFrameRecorder.cpp
@@ -112,6 +112,15 @@ namespace HoloLensForCV
 
             sensorFrameSink->Stop();
 
+        }
+
+        for (SensorFrameRecorderSink^ sensorFrameSink : _sensorFrameSinks)
+        {
+            if (nullptr == sensorFrameSink)
+            {
+                continue;
+            }
+
             sensorFrameSink->ReportArchiveSourceFiles(
                 sourceFiles);
         }

--- a/Shared/HoloLensForCV/SensorFrameRecorderSink.h
+++ b/Shared/HoloLensForCV/SensorFrameRecorderSink.h
@@ -11,20 +11,10 @@
 
 #pragma once
 
+#include "pch.h"
+
 namespace HoloLensForCV
 {
-    //
-    // Subset of sensor frame metadata relevant to the recording process.
-    //
-    struct SensorFrameRecorderLogEntry
-    {
-        Windows::Foundation::DateTime Timestamp;
-        Windows::Foundation::Numerics::float4x4 FrameToOrigin;
-        Windows::Foundation::Numerics::float4x4 CameraViewTransform;
-        Windows::Foundation::Numerics::float4x4 CameraProjectionTransform;
-        std::wstring RelativeImagePath;
-    };
-
     //
     // Saves sensor images originated on device to disk and collects sensor frame
     // metadata that will be used to create the per-sensor recording manifest CSV
@@ -67,7 +57,7 @@ namespace HoloLensForCV
         Windows::Storage::StorageFolder^ _archiveSourceFolder;
         Windows::Storage::StorageFolder^ _dataArchiveSourceFolder;
 
-        std::vector<SensorFrameRecorderLogEntry> _recorderLog;
+        std::unique_ptr<CsvWriter> _csvWriter;
 
         CameraIntrinsics^ _cameraIntrinsics;
     };


### PR DESCRIPTION
1. This fixes some variable name typos
2. The recorder log is now saved as the data is streamed in as opposed to storing the data and then dumping the data in the end. This sometimes could take a very long time for large sequences and it makes the recorded data usable even if the app crashed during the recording session.