### PR TITLE
Add a check for the group display name when selecting Research Mode sensors

### DIFF
--- a/Shared/HoloLensForCV/MediaFrameSourceGroup.cpp
+++ b/Shared/HoloLensForCV/MediaFrameSourceGroup.cpp
@@ -137,6 +137,9 @@ namespace HoloLensForCV
                 const wchar_t* c_HoloLensDevelopmentEditionPhotoVideoSourceGroupDisplayName =
                     L"MN34150";
 
+                const wchar_t* c_HoloLensResearchModeSensorStreamingGroupDisplayName =
+                    L"Sensor Streaming";
+
                 if (MediaFrameSourceGroupType::PhotoVideoCamera == _mediaFrameSourceGroupType &&
                     (0 == wcscmp(c_HoloLensDevelopmentEditionPhotoVideoSourceGroupDisplayName, sourceGroupDisplayName)))
                 {
@@ -151,12 +154,12 @@ namespace HoloLensForCV
                     break;
                 }
 #if ENABLE_HOLOLENS_RESEARCH_MODE_SENSORS
-                else if (MediaFrameSourceGroupType::HoloLensResearchModeSensors == _mediaFrameSourceGroupType)
+                else if (MediaFrameSourceGroupType::HoloLensResearchModeSensors == _mediaFrameSourceGroupType &&
+                    (0 == wcscmp(c_HoloLensResearchModeSensorStreamingGroupDisplayName, sourceGroupDisplayName)))
                 {
 #if DBG_ENABLE_INFORMATIONAL_LOGGING
                     dbg::trace(
-                        L"MediaFrameSourceGroup::InitializeMediaSourceWorkerAsync: assuming '%s' is the HoloLens Sensor Streaming media frame source group.",
-                        sourceGroupDisplayName);
+                        L"MediaFrameSourceGroup::InitializeMediaSourceWorkerAsync: found the HoloLens Sensor Streaming media frame source group.");
 #endif /* DBG_ENABLE_INFORMATIONAL_LOGGING */
 
                     selectedSourceGroup =


### PR DESCRIPTION
Add a check for the group display name when selecting Research Mode sensors.

For historical context, the sensor stream went through a few renames before initial release, and the sample code was made resilient to renames by picking "the other" sensor. This is causing trouble as order of enumeration of streams is not guaranteed, and the source group selection logic did not handle this correctly.