### PR TITLE
Recorder: Add support for PV

### DIFF
--- a/Shared/HoloLensForCV/SensorFrameRecorder.cpp
+++ b/Shared/HoloLensForCV/SensorFrameRecorder.cpp
@@ -15,12 +15,18 @@ namespace HoloLensForCV
 {
     SensorFrameRecorder::SensorFrameRecorder()
     {
+		_isPV = false;
     }
 
     SensorFrameRecorder::~SensorFrameRecorder()
     {
         Stop();
     }
+
+	void SensorFrameRecorder::SetPV()
+	{
+		_isPV = true;
+	}
 
     void SensorFrameRecorder::EnableAll()
     {
@@ -67,11 +73,12 @@ namespace HoloLensForCV
         return concurrency::create_async(
             [this]()
         {
+			Platform::StringReference archivName = _isPV ? L"PVarchiveSource" : L"archiveSource";
             Windows::Storage::StorageFolder^ temporaryStorageFolder =
                 Windows::Storage::ApplicationData::Current->TemporaryFolder;
 
             return concurrency::create_task(temporaryStorageFolder->CreateFolderAsync(
-                L"archiveSource",
+                archivName,
                 Windows::Storage::CreationCollisionOption::ReplaceExisting)).then(
                     [&](Windows::Storage::StorageFolder^ archiveSourceFolder)
                 {
@@ -152,13 +159,14 @@ namespace HoloLensForCV
 
             swprintf_s(
                 archiveName,
-                L"HoloLensRecording__%04i_%02i_%02i__%02i_%02i_%02i",
+                L"HoloLensRecording__%04i_%02i_%02i__%02i_%02i_%02i_%01d",
                 timeNowUtc.tm_year + 1900,
                 timeNowUtc.tm_mon + 1,
                 timeNowUtc.tm_mday,
                 timeNowUtc.tm_hour,
                 timeNowUtc.tm_min,
-                timeNowUtc.tm_sec);
+                timeNowUtc.tm_sec,
+				_isPV);
 
             Platform::String^ archiveNameString =
                 ref new Platform::String(archiveName);

--- a/Shared/HoloLensForCV/SensorFrameRecorder.h
+++ b/Shared/HoloLensForCV/SensorFrameRecorder.h
@@ -44,6 +44,8 @@ namespace HoloLensForCV
         Windows::Foundation::IAsyncAction^ StartAsync();
 
         void Stop();
+		// Set the frame recorder for the PV stream
+		void SetPV();
 
         virtual ISensorFrameSink^ GetSensorFrameSink(
             _In_ SensorType sensorType);
@@ -64,6 +66,7 @@ namespace HoloLensForCV
         std::mutex _recorderMutex;
 
         Windows::Storage::StorageFolder^ _archiveSourceFolder;
+		bool _isPV;
 
         std::array<SensorFrameRecorderSink^, (size_t)SensorType::NumberOfSensorTypes> _sensorFrameSinks;
     };

--- a/Tools/Recorder/AppMain.h
+++ b/Tools/Recorder/AppMain.h
@@ -71,8 +71,23 @@ namespace Recorder
     // Plays the voice command recognition sound.
     void PlayVoiceCommandRecognitionSound();
 
-    // Initializes access to HoloLens sensors.
+    // Initializes access to HoloLens Research Mode sensors.
     void StartHoloLensMediaFrameSourceGroup();
+
+	// Initializes access to HoloLens PV sensor.
+	void StartPVMediaFrameSourceGroup();
+
+	//
+	// Enabling all of the Research Mode sensors at the same time can be quite expensive
+	// performance-wise. It's best to scope down the list of enabled sensors to just those
+	// that are required for a given task. If enabledSensorTypes is empty, all sensors are selected.
+	// To only select a subset, use the commented code below.
+	//
+	std::vector<HoloLensForCV::SensorType> enabledSensorTypes = { };
+	// std::vector<HoloLensForCV::SensorType> enabledSensorTypes = {HoloLensForCV::SensorType::VisibleLightLeftLeft, HoloLensForCV::SensorType::VisibleLightLeftFront};
+	
+	// Enable PV sensor separately
+	bool enablePV = true;
 
   private:
     // Handles playback of the voice UI prompt.
@@ -93,9 +108,17 @@ namespace Recorder
     HoloLensForCV::MediaFrameSourceGroup^ _mediaFrameSourceGroup;
     std::atomic_bool _mediaFrameSourceGroupStarted;
 
+	// Dealing with PV stream separately: Creating PV frame source group
+	HoloLensForCV::MediaFrameSourceGroup^ _PVFrameSourceGroup;
+	std::atomic_bool _PVFrameSourceGroupStarted;
+
     // Sensor stream recorder for the sensor streams.
     HoloLensForCV::SensorFrameRecorder^ _sensorFrameRecorder;
     std::atomic_bool _sensorFrameRecorderStarted;
+
+	// Dealing with PV stream separately: Creating PV frame recorder
+	HoloLensForCV::SensorFrameRecorder^ _PVFrameRecorder;
+	std::atomic_bool _PVFrameRecorderStarted;
 
     // Mutex that restricts to a single recording.
     std::mutex _startStopRecordingMutex;


### PR DESCRIPTION
- Allows capture of both PV / RM streams from the Recorder app, by creating 2 distinct frame source groups / sensor frame recorders (one for PV, one for RM).
- A Boolean (_isPV) checks if the FrameRecorder instance is used for RM or PV streams. This is then used to save data in 2 distinct archives and avoid overwriting between streams. At the end of the recording, the app saves 2 archives with 2 different file names (one with suffix "0" for RM recorded data, one with suffix "1" for PV recorded data).
- It is possible to choose which streams to capture by modifying the enabledSensorTypes vector and the enablePV bool in Recorder/AppMain.h.
- There are inconsistencies in recording when the app is launched for the first time on the device -- since the airtap given to enable access to the camera is detected also to start capture. The problem seems to affects also the Recorder app prior to this PR.

