### PR TITLE
Remove duplicate StreamingCaptureMode initialization setting

### DIFF
--- a/Samples/SensorStreamViewer/SensorStreamViewer.xaml.cpp
+++ b/Samples/SensorStreamViewer/SensorStreamViewer.xaml.cpp
@@ -286,9 +286,6 @@ task<bool> SensorStreamViewer::TryInitializeMediaCaptureAsync(MediaFrameSourceGr
     // instead of preferring GPU D3DSurface images.
     settings->MemoryPreference = MediaCaptureMemoryPreference::Cpu;
 
-    // Only stream video and don't initialize audio capture devices.
-    settings->StreamingCaptureMode = StreamingCaptureMode::Video;
-
     // Initialize MediaCapture with the specified group.
     // This must occur on the UI thread because some device families
     // (such as Xbox) will prompt the user to grant consent for the

--- a/Shared/HoloLensForCV/MediaFrameSourceGroup.cpp
+++ b/Shared/HoloLensForCV/MediaFrameSourceGroup.cpp
@@ -633,12 +633,6 @@ namespace HoloLensForCV
             Windows::Media::Capture::MediaCaptureMemoryPreference::Cpu;
 
         //
-        // Only stream video and don't initialize audio capture devices.
-        //
-        settings->StreamingCaptureMode =
-            Windows::Media::Capture::StreamingCaptureMode::Video;
-
-        //
         // Initialize MediaCapture with the specified group.
         // This must occur on the UI thread because some device families
         // (such as Xbox) will prompt the user to grant consent for the


### PR DESCRIPTION
Removing duplicate code. These settings are already set a few lines above.